### PR TITLE
Redirect after delete action

### DIFF
--- a/src/Phpro/SmartCrud/Controller/CrudController.php
+++ b/src/Phpro/SmartCrud/Controller/CrudController.php
@@ -159,9 +159,10 @@ class CrudController extends AbstractActionController
      */
     public function deleteAction()
     {
-        $data = $this->getRequest()->isPost() ? $this->getRequest()->getPost() : null;
+        $request = $this->getRequest();
+        $data = $request->isPost() ? $request->getPost() : null;
         $result = $this->getSmartService()->run($this->getEntityId(), $data);
-        if ($this->getRequest()->isPost() && $result->isSuccessFull()) {
+        if (($request->isPost() && !$request->isXmlHttpRequest()) && $result->isSuccessFull()) {
             return $this->redirect()->toRoute(null, array('action' => 'list'), true);
         }
         return $this->getViewModelBuilder()->build($this->getRequest(), $result, 'delete');


### PR DESCRIPTION
Redirect in the controller may not occurred while deleting entities via an ajax request. The redirect is handled in javascript (see file assets/smartcrud/js/delete.js -> window.location.reload()). 

